### PR TITLE
Add ALE linter integration for C# with OmniSharp support

### DIFF
--- a/dotfiles/vimrc-coc
+++ b/dotfiles/vimrc-coc
@@ -48,6 +48,7 @@ call plug#begin('~/.vim/plugged')
   Plug 'yuezk/vim-js'
   Plug 'maxmellon/vim-jsx-pretty'
   Plug 'OmniSharp/omnisharp-vim'
+  Plug 'dense-analysis/ale'
 call plug#end()
 
 let g:coc_global_extensions=[ 'coc-css', 'coc-eslint', 'coc-html', 'coc-json', 'coc-prettier', 'coc-spell-checker', 'coc-tsserver', 'coc-yaml', 'coc-snippets', 'coc-powershell', 'coc-rust-analyzer']
@@ -76,8 +77,35 @@ autocmd FileType cs nmap <buffer> <leader>rn <Plug>(omnisharp_rename)
 autocmd FileType cs nmap <buffer> <leader>do <Plug>(omnisharp_code_actions)
 autocmd FileType cs nmap <buffer> <leader>f <Plug>(omnisharp_code_format)
 autocmd FileType cs nmap <buffer> <leader>qf <Plug>(omnisharp_fix_usings)
-autocmd FileType cs nmap <buffer> [g <Plug>(omnisharp_navigate_up)
-autocmd FileType cs nmap <buffer> ]g <Plug>(omnisharp_navigate_down)
+autocmd FileType cs nmap <buffer> [m <Plug>(omnisharp_navigate_up)
+autocmd FileType cs nmap <buffer> ]m <Plug>(omnisharp_navigate_down)
+
+" ============ ALE Configuration ============
+" Only run linters specified in ale_linters
+let g:ale_linters_explicit = 1
+
+" Define linters per filetype
+let g:ale_linters = {
+\   'cs': ['OmniSharp'],
+\}
+
+" Signs for the gutter (emoji)
+let g:ale_sign_error = '❌'
+let g:ale_sign_warning = '⚠️'
+let g:ale_sign_info = '💡'
+
+" Show errors in the sign column
+let g:ale_set_signs = 1
+
+" Highlight the line with errors
+let g:ale_set_highlights = 1
+
+" Show errors in the statusline
+let g:ale_echo_msg_format = '[%linter%] %s [%severity%]'
+
+" Navigate between ALE errors (C# only, CoC handles other filetypes)
+autocmd FileType cs nmap <buffer> <silent> [g <Plug>(ale_previous_wrap)
+autocmd FileType cs nmap <buffer> <silent> ]g <Plug>(ale_next_wrap)
 
 syntax enable
 set number

--- a/dotfiles/vimrc-coc-install
+++ b/dotfiles/vimrc-coc-install
@@ -19,4 +19,5 @@ call plug#begin('~/.vim/plugged')
   Plug 'yuezk/vim-js'
   Plug 'maxmellon/vim-jsx-pretty'
   Plug 'OmniSharp/omnisharp-vim'
+  Plug 'dense-analysis/ale'
 call plug#end()


### PR DESCRIPTION
## Summary
This PR adds ALE (Asynchronous Lint Engine) as a linting solution for C# files, configured to work alongside the existing OmniSharp setup. ALE provides visual feedback through gutter signs, line highlighting, and statusline messages.

## Key Changes
- **Plugin Addition**: Added `dense-analysis/ale` to both vimrc configurations
- **ALE Configuration**: 
  - Configured ALE to only run explicitly specified linters (`ale_linters_explicit = 1`)
  - Set OmniSharp as the linter for C# files
  - Customized gutter signs with emoji indicators (❌ for errors, ⚠️ for warnings, 💡 for info)
  - Enabled sign column display, line highlighting, and statusline error messages
- **Navigation Keybindings**: 
  - Changed C# navigation from `[g`/`]g` (which conflicted with ALE) to `[m`/`]m` for OmniSharp's method navigation
  - Added new `[g`/`]g` bindings for ALE error navigation (C# only, as CoC handles other filetypes)

## Implementation Details
- ALE is configured with `ale_linters_explicit = 1` to prevent unwanted linters from running automatically
- Error message format includes linter name and severity: `[linter] message [severity]`
- Navigation mappings are scoped to C# buffers only to avoid conflicts with other filetypes
- The setup maintains compatibility with existing CoC configuration for non-C# files