### PR TITLE
Add vim-fugitive plugin and improve diff syntax highlighting

### DIFF
--- a/dotfiles/vimrc-coc
+++ b/dotfiles/vimrc-coc
@@ -133,8 +133,8 @@ hi diffRemoved ctermbg=52 guibg=#4a2d2d
 " Fix diff colors for vimdiff
 hi DiffAdd    ctermbg=22 guibg=#2d4a2d
 hi DiffDelete ctermbg=52 guibg=#4a2d2d
-hi DiffChange ctermbg=58 guibg=#4a4a2d
-hi DiffText   ctermbg=94 guibg=#5a4a2d
+hi DiffChange ctermfg=230 ctermbg=58 guifg=#e8e8d0 guibg=#4a4a2d
+hi DiffText   ctermfg=231 ctermbg=130 guifg=#ffffff guibg=#8a5a2d
 
 "let g:airline_theme='oceanicnext'
 

--- a/dotfiles/vimrc-coc
+++ b/dotfiles/vimrc-coc
@@ -49,6 +49,7 @@ call plug#begin('~/.vim/plugged')
   Plug 'maxmellon/vim-jsx-pretty'
   Plug 'OmniSharp/omnisharp-vim'
   Plug 'dense-analysis/ale'
+  Plug 'tpope/vim-fugitive'
 call plug#end()
 
 let g:coc_global_extensions=[ 'coc-css', 'coc-eslint', 'coc-html', 'coc-json', 'coc-prettier', 'coc-spell-checker', 'coc-tsserver', 'coc-yaml', 'coc-snippets', 'coc-powershell', 'coc-rust-analyzer']
@@ -125,6 +126,16 @@ highlight link CocPumMenu Pmenu
 highlight link CocPumVirtualText Comment
 highlight link CocPumShortcut Special
 highlight link CocPumSearch Identifier
+
+" Fix diff colors for better readability (fugitive :Git diff)
+hi diffAdded   ctermbg=22 guibg=#2d4a2d
+hi diffRemoved ctermbg=52 guibg=#4a2d2d
+" Fix diff colors for vimdiff
+hi DiffAdd    ctermbg=22 guibg=#2d4a2d
+hi DiffDelete ctermbg=52 guibg=#4a2d2d
+hi DiffChange ctermbg=58 guibg=#4a4a2d
+hi DiffText   ctermbg=94 guibg=#5a4a2d
+
 "let g:airline_theme='oceanicnext'
 
 " set filetypes as typescriptreact

--- a/dotfiles/vimrc-coc-install
+++ b/dotfiles/vimrc-coc-install
@@ -20,4 +20,5 @@ call plug#begin('~/.vim/plugged')
   Plug 'maxmellon/vim-jsx-pretty'
   Plug 'OmniSharp/omnisharp-vim'
   Plug 'dense-analysis/ale'
+  Plug 'tpope/vim-fugitive'
 call plug#end()


### PR DESCRIPTION
## Summary
This PR enhances the Vim configuration with Git integration capabilities and improves the visual readability of diff output in both fugitive and vimdiff contexts.

## Changes
- **Added vim-fugitive plugin**: Integrates Git commands directly into Vim, enabling seamless Git workflow without leaving the editor
- **Enhanced diff syntax highlighting**: Configured custom colors for diff output to improve readability:
  - `diffAdded` and `DiffAdd`: Dark green background for added lines
  - `diffRemoved` and `DiffDelete`: Dark red background for removed lines
  - `DiffChange`: Dark yellow background for changed lines
  - `DiffText`: Dark orange background for changed text within lines
- **Updated both vimrc files**: Applied changes to both `vimrc-coc` and `vimrc-coc-install` for consistency

## Implementation Details
- Colors use both terminal (`ctermbg`) and GUI (`guibg`) specifications for compatibility across different Vim environments
- The color scheme uses muted, darker tones to reduce eye strain while maintaining clear visual distinction between change types
- vim-fugitive enables commands like `:Git diff`, `:Git status`, `:Git log`, and `:Git blame` directly within Vim

https://claude.ai/code/session_015b9XdjchPriLGEC6dnQ1zD