### PR TITLE
Fix VNC/X11 display initialization and clipboard sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,9 @@ ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
+# Pre-create X11 socket directory so Xvfb can run as non-root
+RUN mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix
+
 #setup dev user
 RUN useradd -ms /bin/bash -u 1002 -G sudo devuser
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN yes | unminimize
 # Add Git PPA for latest stable version
 RUN apt-get update && apt-get install -y software-properties-common
 RUN add-apt-repository -y ppa:git-core/ppa
-RUN apt-get update && apt-get -y install nano vim-gtk3 xclip tmux git fzf ripgrep curl python3 python3-setuptools ssh sqlite3 sudo locales ca-certificates gnupg lsb-release libnss3-tools upower uuid-runtime build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev dbus-x11 libsecret-1-0 libsecret-1-dev libsecret-tools gnome-keyring xdg-utils gstreamer1.0-gl gstreamer1.0-plugins-ugly jq iptables xvfb x11vnc novnc websockify
+RUN apt-get update && apt-get -y install nano vim-gtk3 xclip tmux git fzf ripgrep curl python3 python3-setuptools ssh sqlite3 sudo locales ca-certificates gnupg lsb-release libnss3-tools upower uuid-runtime build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev dbus-x11 libsecret-1-0 libsecret-1-dev libsecret-tools gnome-keyring xdg-utils gstreamer1.0-gl gstreamer1.0-plugins-ugly jq iptables xvfb x11vnc novnc websockify autocutsel
 
 # Install docker cli
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,12 +113,6 @@ COPY dotfiles/coc-settings.json .vim/coc-settings.json
 RUN sudo chown devuser .vim/coc-settings.json
 COPY dotfiles/popup_scroll.vim .vim/autoload/popup_scroll.vim
 
-# Xvfb + noVNC display configuration (placed after vim plugin installs which run headlessly)
-ENV DISPLAY=:99
-ENV VNC_RESOLUTION=1280x1024x24
-ENV VNC_PORT=5900
-ENV NOVNC_PORT=6080
-
 # install powershell
 RUN sudo mkdir -p /opt/microsoft/powershell/7
 RUN arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/x64/) && \
@@ -169,6 +163,13 @@ RUN npm install -g @google/gemini-cli@latest
 RUN npm i -g @openai/codex@latest
 
 RUN npm install -g @microsoft/rush
+
+# Xvfb + noVNC display configuration (placed last so DISPLAY is unset during
+# build RUN steps, preventing bashrc from starting the VNC stack mid-build)
+ENV DISPLAY=:99
+ENV VNC_RESOLUTION=1280x1024x24
+ENV VNC_PORT=5900
+ENV NOVNC_PORT=6080
 
 ENTRYPOINT ["/home/devuser/entrypoint.sh"]
 CMD ["bash"]

--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -47,6 +47,18 @@ source ~/.git-completion.bash
 # github cli auth alias
 alias gha='gh auth login --git-protocol https --web --clipboard'
 
+# Start Xvfb + noVNC stack (once) if not already running
+if ! pgrep -x Xvfb > /dev/null 2>&1; then
+    Xvfb ${DISPLAY} -screen 0 ${VNC_RESOLUTION:-1280x1024x24} -ac +extension GLX +render -noreset &
+    sleep 1
+    autocutsel -fork
+    autocutsel -selection PRIMARY -fork
+    x11vnc -display ${DISPLAY} -forever -shared -rfbport ${VNC_PORT:-5900} -nopw &
+    sleep 0.5
+    websockify --web /usr/share/novnc ${NOVNC_PORT:-6080} localhost:${VNC_PORT:-5900} &
+    echo "noVNC available at http://localhost:${NOVNC_PORT:-6080}/vnc.html"
+fi
+
 # setup dbus which is used by chrome and libsecret/gnome-keyring
 
 export NO_AT_BRIDGE=1 

--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -47,8 +47,9 @@ source ~/.git-completion.bash
 # github cli auth alias
 alias gha='gh auth login --git-protocol https --web --clipboard'
 
-# Start Xvfb + noVNC stack (once) if not already running (skip during docker build)
-if [[ $- == *i* ]] && ! pgrep -x Xvfb > /dev/null 2>&1; then
+# Start Xvfb + noVNC stack (once) if not already running
+# DISPLAY is unset during docker build (ENV is placed after all RUN steps)
+if [[ -n "$DISPLAY" ]] && ! pgrep -x Xvfb > /dev/null 2>&1; then
     Xvfb ${DISPLAY} -screen 0 ${VNC_RESOLUTION:-1280x1024x24} -ac +extension GLX +render -noreset &
     sleep 1
     autocutsel -fork

--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -51,7 +51,10 @@ alias gha='gh auth login --git-protocol https --web --clipboard'
 # DISPLAY is unset during docker build (ENV is placed after all RUN steps)
 if [[ -n "$DISPLAY" ]] && ! pgrep -x Xvfb > /dev/null 2>&1; then
     Xvfb ${DISPLAY} -screen 0 ${VNC_RESOLUTION:-1280x1024x24} -ac +extension GLX +render -noreset &
-    sleep 1
+    for i in $(seq 1 50); do
+        xdpyinfo -display ${DISPLAY} > /dev/null 2>&1 && break
+        sleep 0.1
+    done
     autocutsel -fork
     autocutsel -selection PRIMARY -fork
     x11vnc -display ${DISPLAY} -forever -shared -rfbport ${VNC_PORT:-5900} -nopw &

--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -55,11 +55,11 @@ if [[ -n "$DISPLAY" ]] && ! pgrep -x Xvfb > /dev/null 2>&1; then
         xdpyinfo -display ${DISPLAY} > /dev/null 2>&1 && break
         sleep 0.1
     done
-    autocutsel -fork
-    autocutsel -selection PRIMARY -fork
     x11vnc -display ${DISPLAY} -forever -shared -rfbport ${VNC_PORT:-5900} -nopw &
     sleep 0.5
     websockify --web /usr/share/novnc ${NOVNC_PORT:-6080} localhost:${VNC_PORT:-5900} &
+    autocutsel &
+    autocutsel -selection PRIMARY &
     echo "noVNC available at http://localhost:${NOVNC_PORT:-6080}/vnc.html"
 fi
 

--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -47,8 +47,8 @@ source ~/.git-completion.bash
 # github cli auth alias
 alias gha='gh auth login --git-protocol https --web --clipboard'
 
-# Start Xvfb + noVNC stack (once) if not already running
-if ! pgrep -x Xvfb > /dev/null 2>&1; then
+# Start Xvfb + noVNC stack (once) if not already running (skip during docker build)
+if [[ $- == *i* ]] && ! pgrep -x Xvfb > /dev/null 2>&1; then
     Xvfb ${DISPLAY} -screen 0 ${VNC_RESOLUTION:-1280x1024x24} -ac +extension GLX +render -noreset &
     sleep 1
     autocutsel -fork

--- a/dotfiles/vimrc-coc
+++ b/dotfiles/vimrc-coc
@@ -341,5 +341,5 @@ let g:clipboard = {
         \ '+': 'xclip -selection clipboard -o',
         \ '*': 'xclip -selection clipboard -o',
     \ },
-    \ 'cache_enabled': 1,
+    \ 'cache_enabled': 0,
 \ }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 # Start Xvfb on display :99
 Xvfb ${DISPLAY} -screen 0 ${VNC_RESOLUTION:-1280x1024x24} -ac +extension GLX +render -noreset &
@@ -8,8 +7,8 @@ sleep 1
 # Sync X CLIPBOARD and PRIMARY selections so that:
 #   - vim/tmux yanks (CLIPBOARD) are visible to VNC (PRIMARY)
 #   - noVNC pastes (PRIMARY) are visible to xclip (CLIPBOARD)
-autocutsel -fork
-autocutsel -selection PRIMARY -fork
+autocutsel -fork || echo "Warning: autocutsel (CLIPBOARD) failed to start"
+autocutsel -selection PRIMARY -fork || echo "Warning: autocutsel (PRIMARY) failed to start"
 
 # Start x11vnc (no password — localhost only)
 x11vnc -display ${DISPLAY} -forever -shared -rfbport ${VNC_PORT:-5900} -nopw &

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,12 +9,6 @@ for i in $(seq 1 50); do
     sleep 0.1
 done
 
-# Sync X CLIPBOARD and PRIMARY selections so that:
-#   - vim/tmux yanks (CLIPBOARD) are visible to VNC (PRIMARY)
-#   - noVNC pastes (PRIMARY) are visible to xclip (CLIPBOARD)
-autocutsel -fork || echo "Warning: autocutsel (CLIPBOARD) failed to start"
-autocutsel -selection PRIMARY -fork || echo "Warning: autocutsel (PRIMARY) failed to start"
-
 # Start x11vnc (no password — localhost only)
 x11vnc -display ${DISPLAY} -forever -shared -rfbport ${VNC_PORT:-5900} -nopw &
 sleep 0.5
@@ -22,6 +16,12 @@ sleep 0.5
 # Start noVNC via websockify
 websockify --web /usr/share/novnc ${NOVNC_PORT:-6080} localhost:${VNC_PORT:-5900} &
 sleep 0.5
+
+# Sync X CLIPBOARD and PRIMARY selections so that:
+#   - vim/tmux yanks (CLIPBOARD) are visible to VNC (PRIMARY)
+#   - noVNC pastes (PRIMARY) are visible to xclip (CLIPBOARD)
+autocutsel &
+autocutsel -selection PRIMARY &
 
 echo "noVNC available at http://localhost:${NOVNC_PORT:-6080}/vnc.html"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,12 @@ set -e
 Xvfb ${DISPLAY} -screen 0 ${VNC_RESOLUTION:-1280x1024x24} -ac +extension GLX +render -noreset &
 sleep 1
 
+# Sync X CLIPBOARD and PRIMARY selections so that:
+#   - vim/tmux yanks (CLIPBOARD) are visible to VNC (PRIMARY)
+#   - noVNC pastes (PRIMARY) are visible to xclip (CLIPBOARD)
+autocutsel -fork
+autocutsel -selection PRIMARY -fork
+
 # Start x11vnc (no password — localhost only)
 x11vnc -display ${DISPLAY} -forever -shared -rfbport ${VNC_PORT:-5900} -nopw &
 sleep 0.5

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,12 @@
 
 # Start Xvfb on display :99
 Xvfb ${DISPLAY} -screen 0 ${VNC_RESOLUTION:-1280x1024x24} -ac +extension GLX +render -noreset &
-sleep 1
+
+# Wait for Xvfb to be ready (up to 5s)
+for i in $(seq 1 50); do
+    xdpyinfo -display ${DISPLAY} > /dev/null 2>&1 && break
+    sleep 0.1
+done
 
 # Sync X CLIPBOARD and PRIMARY selections so that:
 #   - vim/tmux yanks (CLIPBOARD) are visible to VNC (PRIMARY)


### PR DESCRIPTION
## Summary
This PR improves the VNC and X11 display initialization process by moving display environment variables to the end of the Dockerfile build, adding clipboard synchronization, and implementing more robust display readiness checks.

## Key Changes

- **Dockerfile**: 
  - Added `autocutsel` package for clipboard synchronization between X11 selections
  - Pre-created `/tmp/.X11-unix` directory with proper permissions to allow Xvfb to run as non-root
  - Moved `DISPLAY`, `VNC_RESOLUTION`, `VNC_PORT`, and `NOVNC_PORT` environment variables to the end of the build (after all RUN steps) to prevent VNC stack from starting during intermediate build steps

- **entrypoint.sh**:
  - Replaced fixed `sleep 1` with a robust polling mechanism that waits up to 5 seconds for Xvfb to be ready using `xdpyinfo`
  - Removed `set -e` to allow graceful handling of display initialization
  - Added `autocutsel` processes to sync X11 CLIPBOARD and PRIMARY selections, enabling proper copy/paste between vim/tmux and VNC clients

- **dotfiles/bashrc**:
  - Added conditional logic to start the VNC stack (Xvfb, x11vnc, websockify, autocutsel) once per session if not already running
  - Includes the same robust display readiness polling as entrypoint.sh
  - Only starts when `DISPLAY` is set (which happens after Docker build completes)

- **dotfiles/vimrc-coc**:
  - Disabled clipboard cache (`cache_enabled: 0`) to ensure fresh clipboard state on each operation

## Implementation Details

The key insight is that `DISPLAY` environment variable placement controls when the VNC stack starts. By moving it to the end of the Dockerfile, intermediate build steps run headlessly, preventing unnecessary VNC processes during the build. The VNC stack then starts automatically when the container is entered via bashrc or entrypoint.sh, with proper clipboard synchronization to bridge vim/tmux yanks with VNC client pastes.

https://claude.ai/code/session_01XTeLafFvb6rwjMqUDs474M