### PR TITLE
Disable Claude AI MCP servers in experimental container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     environment:
       - MCP_GATEWAY_AUTH_TOKEN=${MCP_GATEWAY_AUTH_TOKEN}
       - ADO_ORG=${ADO_ORG}
+      - ENABLE_CLAUDEAI_MCP_SERVERS=false
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     security_opt:

--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -80,5 +80,5 @@ fi
 
 # Claude Code YOLO mode alias (only available in the experimental container)
 if [[ -n "$EXP_CONTAINER" ]]; then
-    alias claude-yolo='claude --dangerously-skip-permissions'
+    alias claude-yolo='ENABLE_CLAUDEAI_MCP_SERVERS=false claude --dangerously-skip-permissions'
 fi


### PR DESCRIPTION
## Summary
Disables Claude AI MCP (Model Context Protocol) servers in the experimental container environment by setting the `ENABLE_CLAUDEAI_MCP_SERVERS` environment variable to `false`.

## Changes
- Added `ENABLE_CLAUDEAI_MCP_SERVERS=false` environment variable to the Docker Compose service configuration
- Updated the `claude-yolo` bash alias to set `ENABLE_CLAUDEAI_MCP_SERVERS=false` when invoked in the experimental container

## Details
This change ensures that Claude AI MCP servers are consistently disabled across both the containerized environment and the experimental shell alias. The environment variable is set at the Docker Compose level for the service and also explicitly passed when using the `claude-yolo` alias to guarantee the setting is applied regardless of how Claude is invoked.

https://claude.ai/code/session_016R3axw8CmfKiK1LLKeLfZn