### PR TITLE
Add Ollama CLI integration and version checking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 # check=skip=SecretsUsedInArgOrEnv
+ARG OLLAMA_VERSION=0.20.2
+FROM ollama/ollama:${OLLAMA_VERSION} AS ollama-source
+
 FROM mcr.microsoft.com/playwright:v1.45.3-noble AS sam-dev
 
 ARG D2_VERSION=0.7.1
@@ -165,6 +168,11 @@ RUN npm install -g @google/gemini-cli@latest
 # install Codex
 RUN npm i -g @openai/codex@latest
 
+# Install ollama CLI from official Docker image (client only — connects to
+# server on the host). Pinned version via the ollama-source build stage.
+COPY --from=ollama-source /bin/ollama /usr/bin/ollama
+ENV OLLAMA_HOST=http://host.docker.internal:11434
+
 RUN npm install -g @microsoft/rush
 
 # Xvfb + noVNC display configuration (placed last so DISPLAY is unset during
@@ -186,4 +194,7 @@ RUN apk add --no-cache tinyproxy socat dnsmasq iptables ip6tables bash
 COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
 COPY entrypoint-proxy.sh /entrypoint-proxy.sh
 RUN chmod 755 /entrypoint-proxy.sh
+# Install ollama CLI from official Docker image (client only)
+COPY --from=ollama-source /bin/ollama /usr/bin/ollama
+ENV OLLAMA_HOST=http://host.docker.internal:11434
 ENTRYPOINT ["/entrypoint-proxy.sh"]

--- a/docker-compose.exp.yml
+++ b/docker-compose.exp.yml
@@ -42,6 +42,7 @@ services:
     environment:
       - EXP_CONTAINER=1
       - OAUTH2_FORWARDER_SERVER=proxy:48272
+      - OLLAMA_HOST=http://proxy:11434
       - HTTP_PROXY=http://proxy:8888
       - HTTPS_PROXY=http://proxy:8888
       - http_proxy=http://proxy:8888

--- a/entrypoint-proxy.sh
+++ b/entrypoint-proxy.sh
@@ -30,6 +30,9 @@ $IPTABLES -A OUTPUT -d "$HOST_IP" -m state --state ESTABLISHED,RELATED -j ACCEPT
 # Allow TCP to port 48272 (OAuth2 forwarder)
 $IPTABLES -A OUTPUT -d "$HOST_IP" -p tcp --dport 48272 -j ACCEPT
 
+# Allow TCP to port 11434 (Ollama API on the host)
+$IPTABLES -A OUTPUT -d "$HOST_IP" -p tcp --dport 11434 -j ACCEPT
+
 # Allow DNS to host (Docker Desktop routes DNS through the host gateway)
 $IPTABLES -A OUTPUT -d "$HOST_IP" -p udp --dport 53 -j ACCEPT
 $IPTABLES -A OUTPUT -d "$HOST_IP" -p tcp --dport 53 -j ACCEPT
@@ -37,7 +40,7 @@ $IPTABLES -A OUTPUT -d "$HOST_IP" -p tcp --dport 53 -j ACCEPT
 # Block everything else to the host
 $IPTABLES -A OUTPUT -d "$HOST_IP" -j REJECT
 
-echo "iptables applied: host access restricted to port 48272 + DNS only"
+echo "iptables applied: host access restricted to ports 48272, 11434 + DNS only"
 
 # --- Start dnsmasq ---
 # Forward DNS queries to Docker's embedded DNS (127.0.0.11)
@@ -59,6 +62,11 @@ echo "dnsmasq started (PID: $DNSMASQ_PID)"
 socat TCP-LISTEN:48272,fork,reuseaddr TCP:host.docker.internal:48272 &
 SOCAT_PID=$!
 echo "socat TCP forwarder started: 48272 -> host.docker.internal:48272 (PID: $SOCAT_PID)"
+
+# --- Start socat for Ollama API ---
+socat TCP-LISTEN:11434,fork,reuseaddr TCP:host.docker.internal:11434 &
+SOCAT_OLLAMA_PID=$!
+echo "socat TCP forwarder started: 11434 -> host.docker.internal:11434 (PID: $SOCAT_OLLAMA_PID)"
 
 # --- Start tinyproxy ---
 echo "Starting tinyproxy on port 8888..."

--- a/run-exp.sh
+++ b/run-exp.sh
@@ -22,6 +22,23 @@ if [[ -n "$ADO_ORG" && "$ADO_ORG" == "your-org-name" ]]; then
     unset ADO_ORG
 fi
 
+# Check for newer Ollama version (non-blocking)
+check_ollama_version() {
+    local pinned
+    pinned=$(grep -m1 '^ARG OLLAMA_VERSION=' Dockerfile 2>/dev/null | cut -d= -f2)
+    if [[ -z "$pinned" ]]; then return; fi
+    local latest
+    latest=$(curl -sfL -o /dev/null -w '%{url_effective}' https://github.com/ollama/ollama/releases/latest 2>/dev/null \
+        | grep -oP 'v\K[0-9]+\.[0-9]+\.[0-9]+')
+    if [[ -n "$latest" && "$latest" != "$pinned" ]]; then
+        echo ""
+        echo "*** Ollama update available: $pinned -> $latest ***"
+        echo "    Update OLLAMA_VERSION in Dockerfile and rebuild to upgrade."
+        echo ""
+    fi
+}
+check_ollama_version &
+
 # Configuration
 IMAGE_TARGET="sam-dev"
 IMAGE_TAG="sam-exp-container"

--- a/run.sh
+++ b/run.sh
@@ -15,6 +15,23 @@ if [[ -n "$ADO_ORG" && "$ADO_ORG" == "your-org-name" ]]; then
     unset ADO_ORG
 fi
 
+# Check for newer Ollama version (non-blocking)
+check_ollama_version() {
+    local pinned
+    pinned=$(grep -m1 '^ARG OLLAMA_VERSION=' Dockerfile 2>/dev/null | cut -d= -f2)
+    if [[ -z "$pinned" ]]; then return; fi
+    local latest
+    latest=$(curl -sfL -o /dev/null -w '%{url_effective}' https://github.com/ollama/ollama/releases/latest 2>/dev/null \
+        | grep -oP 'v\K[0-9]+\.[0-9]+\.[0-9]+')
+    if [[ -n "$latest" && "$latest" != "$pinned" ]]; then
+        echo ""
+        echo "*** Ollama update available: $pinned -> $latest ***"
+        echo "    Update OLLAMA_VERSION in Dockerfile and rebuild to upgrade."
+        echo ""
+    fi
+}
+check_ollama_version &
+
 # Configuration
 IMAGE_TARGET="sam-dev"
 IMAGE_TAG="sam-dev-container"


### PR DESCRIPTION
## Summary
This PR adds Ollama CLI integration to the development container and implements a non-blocking version checker to notify users when updates are available.

## Key Changes

- **Ollama CLI Installation**: Added Ollama binary to both the main and proxy Docker images via multi-stage build, allowing containers to communicate with an Ollama server running on the host
- **Version Checking**: Implemented `check_ollama_version()` function in both `run.sh` and `run-exp.sh` that:
  - Extracts the pinned Ollama version from the Dockerfile
  - Fetches the latest available version from GitHub releases
  - Displays a non-blocking notification if an update is available
  - Runs asynchronously to avoid delaying script execution
- **Network Configuration**: 
  - Updated `entrypoint-proxy.sh` to allow TCP traffic on port 11434 (Ollama API) through iptables
  - Added socat TCP forwarder for port 11434 to route requests to the host
  - Updated log message to reflect new port allowlist
- **Environment Setup**:
  - Set `OLLAMA_HOST` environment variable in both container images and docker-compose configuration to point to the host's Ollama server
  - Configured containers to connect via `host.docker.internal` on port 11434

## Implementation Details

- The Ollama version is pinned via `ARG OLLAMA_VERSION=0.20.2` in the Dockerfile and used in a multi-stage build to extract the binary
- Version checking uses curl to follow GitHub's redirect to the latest release and extracts the version with grep
- The check runs in the background (`&`) to prevent blocking the main script execution
- Both development and proxy containers receive the Ollama CLI installation for consistency

https://claude.ai/code/session_019hY8fVG6rJcPzGMBZ5owRf