### PR TITLE
Add Tailscale sidecar for tailnet access in dev container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # check=skip=SecretsUsedInArgOrEnv
-ARG OLLAMA_VERSION=0.20.5
+ARG OLLAMA_VERSION=0.21.2
 FROM ollama/ollama:${OLLAMA_VERSION} AS ollama-source
 
 FROM mcr.microsoft.com/playwright:v1.45.3-noble AS sam-dev

--- a/README.md
+++ b/README.md
@@ -6,25 +6,31 @@ Dockerfile and scripts to setup a linux dev environment pre-configured for using
 
 - Copy your `.gitconfig` file into the root of this repo (will not be committed to version control)
 - Modify `dotfiles/bashrc` to your taste (e.g., remove vi mode if you aren't a vi user)
+- Copy `settings.example` to `.settings` and set `TS_AUTHKEY` (required — see [Tailscale](#tailscale) below). Optionally set `ADO_ORG` to enable the Azure DevOps MCP.
 - Use `./run.sh` to build and run the dev container
 - On WSL, it is helpful if your user and group guid is set to 1002 to match the devuser in these containers
 
 ## Architecture
 
-The dev environment uses Docker Compose to run two containers:
+The dev environment uses Docker Compose to run two containers, plus an MCP gateway started on the host by `run.sh`:
 
-1. **MCP Gateway** (`mcp-gateway`) - Provides Docker access to Claude via MCP servers
-2. **Dev Container** (`dev`) - The development environment with vim, Claude Code, etc.
+1. **MCP Gateway** (host process) - Provides Docker access to Claude via MCP servers, listening on `localhost:8811`
+2. **Tailscale Sidecar** (`tailscale`) - Owns the network namespace shared with the dev container; provides outbound tailnet access and MagicDNS
+3. **Dev Container** (`dev`) - The development environment with vim, Claude Code, etc., sharing the sidecar's network namespace via `network_mode: service:tailscale`
 
 ```
 Host (Docker Desktop)
-├── MCP Gateway Container
-│   ├── Mounts Docker socket
-│   └── Exposes SSE endpoint for MCP
+├── MCP Gateway (host process on :8811)
 │
-└── Dev Container
+├── Tailscale Sidecar
+│   ├── Owns the shared network namespace
+│   ├── Publishes ports to the host (3002, 3010-3019, 6080)
+│   └── tailscale0 interface (shields-up: no inbound from peers)
+│
+└── Dev Container (network_mode: service:tailscale)
     ├── Claude Code (connects to gateway via MCP)
-    └── No direct Docker socket access
+    ├── Reaches tailnet peers by MagicDNS name
+    └── Shares loopback + interfaces with the sidecar
 ```
 
 ### Docker Access via Claude
@@ -41,6 +47,44 @@ Use `/mcp` in Claude to verify the connection. Then ask Claude to run Docker com
 The docker socket is also bound into the container. Claude will not use it (it will use the MCP), but you can use the docker cli directly.
 
 The host's .docker/mcp directory is mounted as well which allows you to use `docker mcp` commands to configure the gateway from inside the container. Note any secrets that you set will saved on your host.
+
+## Tailscale
+
+The `tailscale` sidecar gives the dev container outbound access to your tailnet, including MagicDNS resolution for peer hostnames. The dev container shares the sidecar's network namespace, so no Tailscale client is installed in the dev image itself — `curl http://my-peer:8080` and `getent hosts my-peer` just work.
+
+### Setup
+
+Generate a reusable, ephemeral auth key at <https://login.tailscale.com/admin/settings/keys> and put it in `.settings`:
+
+```sh
+TS_AUTHKEY="tskey-auth-..."
+```
+
+`run.sh` validates this before bringing the stack up. Teardown flags (`-k`, `-r`, `-x`) work without a key set.
+
+The sidecar registers in your tailnet using `HOSTNAME` (default `sam-dev`) as its device name. Tailscale state persists in the `tailscale-state` named volume, so the device doesn't re-register on every run. `docker compose down -v` would wipe it.
+
+### Inbound is blocked (shields-up)
+
+The sidecar runs with `--shields-up`, which blocks all inbound connections from tailnet peers. Outbound connections and MagicDNS still work. Host port publishing (e.g. `localhost:3002`) is unaffected because that traffic arrives on the sidecar's docker bridge interface, not on `tailscale0`.
+
+If a process in the dev container binds to `0.0.0.0`, shields-up is what prevents it from being reachable from the tailnet. Bind to `127.0.0.1` if you want to be doubly sure.
+
+### Network namespace sharing
+
+Because `dev` uses `network_mode: service:tailscale`:
+
+- All `ports:` declarations live on the `tailscale` service, not `dev`.
+- `localhost` inside dev reaches anything tailscaled is listening on, and vice versa. Avoid port collisions with tailscaled's local API.
+- `/etc/resolv.conf` in dev points at tailscaled's resolver — that's how MagicDNS works.
+- `ip addr` in dev shows the sidecar's interfaces, including `tailscale0`.
+- If the sidecar restarts, the dev container loses its network until both come back. `./run.sh` recovers.
+
+### Kernel vs userspace mode
+
+The sidecar uses kernel networking (`TS_USERSPACE=false`) which requires `/dev/net/tun` and `NET_ADMIN`/`NET_RAW` caps. This works out of the box on Docker Desktop (Mac, Windows, WSL) because Docker's Linux VM ships with the `tun` module.
+
+If you ever run on an engine that doesn't expose `/dev/net/tun` (some Colima/Lima profiles, minimal Linux hosts), flip `TS_USERSPACE=true` in `docker-compose.yml` and drop the tun mount + caps. In userspace mode there's no `tailscale0` interface, so apps reach the tailnet via tailscaled's SOCKS5 proxy on `localhost:1055` (`ALL_PROXY=socks5h://localhost:1055`).
 
 ## run.sh
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Dockerfile and scripts to setup a linux dev environment pre-configured for using
 
 - Copy your `.gitconfig` file into the root of this repo (will not be committed to version control)
 - Modify `dotfiles/bashrc` to your taste (e.g., remove vi mode if you aren't a vi user)
-- Copy `settings.example` to `.settings` and set `TS_AUTHKEY` (required — see [Tailscale](#tailscale) below). Optionally set `ADO_ORG` to enable the Azure DevOps MCP.
+- Copy `settings.example` to `.settings`. Set `TS_AUTHKEY` to enable tailnet access from the dev container (optional — without it the sidecar runs in passive mode; see [Tailscale](#tailscale) below). Set `ADO_ORG` to enable the Azure DevOps MCP.
 - Use `./run.sh` to build and run the dev container
 - On WSL, it is helpful if your user and group guid is set to 1002 to match the devuser in these containers
 
@@ -60,9 +60,11 @@ Generate a reusable, ephemeral auth key at <https://login.tailscale.com/admin/se
 TS_AUTHKEY="tskey-auth-..."
 ```
 
-`run.sh` validates this before bringing the stack up. Teardown flags (`-k`, `-r`, `-x`) work without a key set.
-
 The sidecar registers in your tailnet using `HOSTNAME` (default `sam-dev`) as its device name. Tailscale state persists in the `tailscale-state` named volume, so the device doesn't re-register on every run. `docker compose down -v` would wipe it.
+
+### Passive mode (no TS_AUTHKEY)
+
+If `TS_AUTHKEY` is unset or left as the placeholder, `run.sh` layers `docker-compose.no-tailscale.yml` over the base config. This swaps the sidecar's entrypoint for `sleep infinity` — tailscaled never starts, so there's no tailnet access and no MagicDNS for tailnet hosts. The container itself stays up to own the shared network namespace, so the dev container gets standard docker bridge networking (internet, host access, MCP gateway) exactly as it would without any sidecar. Add a `TS_AUTHKEY` later and re-run `./run.sh -k && ./run.sh` to enable tailnet access.
 
 ### Inbound is blocked (shields-up)
 

--- a/docker-compose.no-tailscale.yml
+++ b/docker-compose.no-tailscale.yml
@@ -1,0 +1,9 @@
+services:
+  tailscale:
+    entrypoint:
+      - sh
+      - -c
+      - |
+        echo "Tailscale disabled (TS_AUTHKEY not set in .settings)."
+        echo "Sidecar is providing docker bridge networking only - no tailnet access."
+        exec sleep infinity

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,33 @@
 services:
-  dev:
-    image: ${IMAGE_TAG:-sam-dev-container}
-    container_name: ${CONTAINER_NAME:-sam-dev-container-active}
+  tailscale:
+    image: tailscale/tailscale:latest
+    container_name: ${CONTAINER_NAME:-sam-dev-container-active}-ts
+    hostname: ${HOSTNAME:-sam-dev}
+    environment:
+      - TS_AUTHKEY=${TS_AUTHKEY}
+      - TS_HOSTNAME=${HOSTNAME:-sam-dev}
+      - TS_USERSPACE=false
+      - TS_STATE_DIR=/var/lib/tailscale
+      - TS_EXTRA_ARGS=--shields-up --accept-dns=true
+    volumes:
+      - tailscale-state:/var/lib/tailscale
+      - /dev/net/tun:/dev/net/tun
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
     ports:
       - "${HOST_PORTS:-3002}:${CONTAINER_PORTS:-3000}"
       - "${HOST_PORT_RANGE:-3010-3019}:${CONTAINER_PORT_RANGE:-3010-3019}"
       - "${NOVNC_HOST_PORT:-6080}:6080"
+    restart: unless-stopped
+
+  dev:
+    image: ${IMAGE_TAG:-sam-dev-container}
+    container_name: ${CONTAINER_NAME:-sam-dev-container-active}
+    network_mode: "service:tailscale"
+    depends_on:
+      - tailscale
     shm_size: 2gb
-    hostname: ${HOSTNAME:-sam-dev}
     environment:
       - MCP_GATEWAY_AUTH_TOKEN=${MCP_GATEWAY_AUTH_TOKEN}
       - ADO_ORG=${ADO_ORG}
@@ -18,3 +38,6 @@ services:
       - seccomp=custom-seccomp.json
     stdin_open: true
     tty: true
+
+volumes:
+  tailscale-state:

--- a/run.sh
+++ b/run.sh
@@ -114,6 +114,16 @@ else
 fi
 export MCP_GATEWAY_AUTH_TOKEN
 export ADO_ORG
+export TS_AUTHKEY
+
+# Validate TS_AUTHKEY (required for the tailscale sidecar to come up).
+# Run this after getopts so teardown flags (-k/-r/-x) work without a key set.
+if [[ -z "$TS_AUTHKEY" || "$TS_AUTHKEY" == "tskey-auth-..." ]]; then
+    echo "Error: TS_AUTHKEY not set - the tailscale sidecar cannot start."
+    echo "  Generate a key at https://login.tailscale.com/admin/settings/keys"
+    echo "  and set TS_AUTHKEY in .settings (see settings.example)."
+    exit 1
+fi
 
 # Set up compose files
 COMPOSE_FILES="-f docker-compose.yml"

--- a/run.sh
+++ b/run.sh
@@ -116,17 +116,18 @@ export MCP_GATEWAY_AUTH_TOKEN
 export ADO_ORG
 export TS_AUTHKEY
 
-# Validate TS_AUTHKEY (required for the tailscale sidecar to come up).
-# Run this after getopts so teardown flags (-k/-r/-x) work without a key set.
-if [[ -z "$TS_AUTHKEY" || "$TS_AUTHKEY" == "tskey-auth-..." ]]; then
-    echo "Error: TS_AUTHKEY not set - the tailscale sidecar cannot start."
-    echo "  Generate a key at https://login.tailscale.com/admin/settings/keys"
-    echo "  and set TS_AUTHKEY in .settings (see settings.example)."
-    exit 1
-fi
-
 # Set up compose files
 COMPOSE_FILES="-f docker-compose.yml"
+
+# If TS_AUTHKEY is not set, run the tailscale sidecar in passive mode
+# (no tailnet, just holds the netns so dev gets normal docker bridge networking).
+# Run this after getopts so teardown flags (-k/-r/-x) are unaffected.
+if [[ -z "$TS_AUTHKEY" || "$TS_AUTHKEY" == "tskey-auth-..." ]]; then
+    echo "Warning: TS_AUTHKEY not set - tailscale sidecar will run in passive mode."
+    echo "  No tailnet access; dev container has standard docker bridge networking."
+    echo "  To enable tailnet access, set TS_AUTHKEY in .settings (see settings.example)."
+    COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.no-tailscale.yml"
+fi
 
 # Start host MCP gateway if not already running
 if ! curl -s http://localhost:8811/health > /dev/null 2>&1; then

--- a/settings.example
+++ b/settings.example
@@ -4,3 +4,9 @@
 
 # Azure DevOps organization name (the part after dev.azure.com/)
 ADO_ORG="your-org-name"
+
+# Tailscale auth key for the sidecar (https://login.tailscale.com/admin/settings/keys)
+# A reusable, ephemeral key is recommended. The container registers in your
+# tailnet using HOSTNAME as its device name and runs in shields-up mode, so it
+# can dial peers via MagicDNS but peers cannot dial it.
+TS_AUTHKEY="tskey-auth-..."


### PR DESCRIPTION
## Summary
This PR adds a Tailscale sidecar container that provides the dev environment with outbound access to your tailnet, including MagicDNS resolution for peer hostnames. The dev container now shares the sidecar's network namespace instead of having its own isolated network.

## Key Changes

- **Tailscale sidecar service**: New `tailscale` service in `docker-compose.yml` that owns the shared network namespace, with kernel-mode networking (`/dev/net/tun`), `shields-up` mode (blocks inbound from peers), and persistent state via named volume
- **Network namespace sharing**: Dev container now uses `network_mode: service:tailscale` to share the sidecar's network stack, enabling MagicDNS and outbound tailnet access without a separate Tailscale client in the dev image
- **Port publishing moved**: All `ports:` declarations now live on the `tailscale` service rather than `dev`, since the sidecar owns the network namespace
- **Passive mode fallback**: New `docker-compose.no-tailscale.yml` overlay that disables the sidecar when `TS_AUTHKEY` is not set, allowing the sidecar to still own the netns but run in sleep mode, preserving standard docker bridge networking
- **Configuration**: Updated `settings.example` with `TS_AUTHKEY` field and added comprehensive Tailscale documentation to README covering setup, passive mode, shields-up behavior, namespace sharing implications, and kernel vs userspace mode
- **run.sh logic**: Added check to layer the no-tailscale override when `TS_AUTHKEY` is unset or placeholder, with user-friendly warning messages
- **Ollama version bump**: Updated from 0.20.5 to 0.21.2

## Notable Implementation Details

- The sidecar uses `TS_USERSPACE=false` (kernel mode) which requires `/dev/net/tun` and `NET_ADMIN`/`NET_RAW` capabilities — works out of the box on Docker Desktop
- Tailscale state persists in a named volume so the device doesn't re-register on every container restart
- `shields-up` prevents inbound connections from tailnet peers but doesn't affect host port publishing (traffic arrives on docker bridge interface)
- Dev container's `/etc/resolv.conf` points to the sidecar's resolver, enabling MagicDNS without additional configuration
- Passive mode allows users to start without tailnet access and enable it later by setting `TS_AUTHKEY` and re-running `./run.sh`

https://claude.ai/code/session_01Gv2LUgpks529oBVePXncLi