### PR TITLE
Make tailscale sidecar opt-in via -t flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,32 +6,28 @@ Dockerfile and scripts to setup a linux dev environment pre-configured for using
 
 - Copy your `.gitconfig` file into the root of this repo (will not be committed to version control)
 - Modify `dotfiles/bashrc` to your taste (e.g., remove vi mode if you aren't a vi user)
-- Copy `settings.example` to `.settings`. Set `TS_AUTHKEY` to enable tailnet access from the dev container (optional — without it the sidecar runs in passive mode; see [Tailscale](#tailscale) below). Set `ADO_ORG` to enable the Azure DevOps MCP.
+- Copy `settings.example` to `.settings`. Set `ADO_ORG` to enable the Azure DevOps MCP. Set `TS_AUTHKEY` if you plan to opt into the tailscale sidecar (see [Tailscale](#tailscale) below); it is not required for the default single-container setup.
 - Use `./run.sh` to build and run the dev container
 - On WSL, it is helpful if your user and group guid is set to 1002 to match the devuser in these containers
 
 ## Architecture
 
-The dev environment uses Docker Compose to run two containers, plus an MCP gateway started on the host by `run.sh`:
+By default the dev environment runs a single container with standard docker bridge networking, plus an MCP gateway started on the host by `run.sh`:
 
 1. **MCP Gateway** (host process) - Provides Docker access to Claude via MCP servers, listening on `localhost:8811`
-2. **Tailscale Sidecar** (`tailscale`) - Owns the network namespace shared with the dev container; provides outbound tailnet access and MagicDNS
-3. **Dev Container** (`dev`) - The development environment with vim, Claude Code, etc., sharing the sidecar's network namespace via `network_mode: service:tailscale`
+2. **Dev Container** (`dev`) - The development environment with vim, Claude Code, etc.; ports published directly to the host (3002, 3010-3019, 6080)
 
 ```
 Host (Docker Desktop)
 ├── MCP Gateway (host process on :8811)
 │
-├── Tailscale Sidecar
-│   ├── Owns the shared network namespace
-│   ├── Publishes ports to the host (3002, 3010-3019, 6080)
-│   └── tailscale0 interface (shields-up: no inbound from peers)
-│
-└── Dev Container (network_mode: service:tailscale)
-    ├── Claude Code (connects to gateway via MCP)
-    ├── Reaches tailnet peers by MagicDNS name
-    └── Shares loopback + interfaces with the sidecar
+└── Dev Container
+    ├── Standard docker bridge networking
+    ├── Publishes ports to the host (3002, 3010-3019, 6080)
+    └── Claude Code (connects to gateway via MCP)
 ```
+
+Pass `-t` to `run.sh` to opt into a Tailscale sidecar that owns the dev container's network namespace and provides outbound tailnet access. See [Tailscale](#tailscale) for details and trade-offs.
 
 ### Docker Access via Claude
 
@@ -50,7 +46,24 @@ The host's .docker/mcp directory is mounted as well which allows you to use `doc
 
 ## Tailscale
 
-The `tailscale` sidecar gives the dev container outbound access to your tailnet, including MagicDNS resolution for peer hostnames. The dev container shares the sidecar's network namespace, so no Tailscale client is installed in the dev image itself — `curl http://my-peer:8080` and `getent hosts my-peer` just work.
+The tailscale sidecar is **optional** and disabled by default. Pass `-t` to `run.sh` to enable it. The default single-container setup is more reliable on machines that change networks (e.g. laptops moving between wifi networks), since there's no sidecar holding the network namespace that can lose its connection independently of the dev container.
+
+When enabled with `-t`, the `tailscale` sidecar gives the dev container outbound access to your tailnet, including MagicDNS resolution for peer hostnames. The dev container shares the sidecar's network namespace, so no Tailscale client is installed in the dev image itself — `curl http://my-peer:8080` and `getent hosts my-peer` just work.
+
+```
+Host (Docker Desktop)
+├── MCP Gateway (host process on :8811)
+│
+├── Tailscale Sidecar
+│   ├── Owns the shared network namespace
+│   ├── Publishes ports to the host (3002, 3010-3019, 6080)
+│   └── tailscale0 interface (shields-up: no inbound from peers)
+│
+└── Dev Container (network_mode: service:tailscale)
+    ├── Claude Code (connects to gateway via MCP)
+    ├── Reaches tailnet peers by MagicDNS name
+    └── Shares loopback + interfaces with the sidecar
+```
 
 ### Setup
 
@@ -60,11 +73,9 @@ Generate a reusable, ephemeral auth key at <https://login.tailscale.com/admin/se
 TS_AUTHKEY="tskey-auth-..."
 ```
 
-The sidecar registers in your tailnet using `HOSTNAME` (default `sam-dev`) as its device name. Tailscale state persists in the `tailscale-state` named volume, so the device doesn't re-register on every run. `docker compose down -v` would wipe it.
+Then start with `./run.sh -t`. The sidecar registers in your tailnet using `HOSTNAME` (default `sam-dev`) as its device name. Tailscale state persists in the `tailscale-state` named volume, so the device doesn't re-register on every run. `docker compose down -v` would wipe it.
 
-### Passive mode (no TS_AUTHKEY)
-
-If `TS_AUTHKEY` is unset or left as the placeholder, `run.sh` layers `docker-compose.no-tailscale.yml` over the base config. This swaps the sidecar's entrypoint for `sleep infinity` — tailscaled never starts, so there's no tailnet access and no MagicDNS for tailnet hosts. The container itself stays up to own the shared network namespace, so the dev container gets standard docker bridge networking (internet, host access, MCP gateway) exactly as it would without any sidecar. Add a `TS_AUTHKEY` later and re-run `./run.sh -k && ./run.sh` to enable tailnet access.
+`-t` requires `TS_AUTHKEY` to be set; otherwise `run.sh` exits with an error. Omit `-t` to run without the sidecar.
 
 ### Inbound is blocked (shields-up)
 
@@ -86,7 +97,7 @@ Because `dev` uses `network_mode: service:tailscale`:
 
 The sidecar uses kernel networking (`TS_USERSPACE=false`) which requires `/dev/net/tun` and `NET_ADMIN`/`NET_RAW` caps. This works out of the box on Docker Desktop (Mac, Windows, WSL) because Docker's Linux VM ships with the `tun` module.
 
-If you ever run on an engine that doesn't expose `/dev/net/tun` (some Colima/Lima profiles, minimal Linux hosts), flip `TS_USERSPACE=true` in `docker-compose.yml` and drop the tun mount + caps. In userspace mode there's no `tailscale0` interface, so apps reach the tailnet via tailscaled's SOCKS5 proxy on `localhost:1055` (`ALL_PROXY=socks5h://localhost:1055`).
+If you ever run on an engine that doesn't expose `/dev/net/tun` (some Colima/Lima profiles, minimal Linux hosts), flip `TS_USERSPACE=true` in `docker-compose.tailscale.yml` and drop the tun mount + caps. In userspace mode there's no `tailscale0` interface, so apps reach the tailnet via tailscaled's SOCKS5 proxy on `localhost:1055` (`ALL_PROXY=socks5h://localhost:1055`).
 
 ## run.sh
 
@@ -113,6 +124,10 @@ Stop containers and delete image
 `./run.sh -b`
 
 Force rebuild the image with --no-cache
+
+`./run.sh -t`
+
+Run with the tailscale sidecar for outbound tailnet access. Requires `TS_AUTHKEY` to be set in `.settings`. Without `-t`, the dev container runs standalone with standard docker bridge networking (the default).
 
 `./run.sh -h`
 

--- a/docker-compose.no-tailscale.yml
+++ b/docker-compose.no-tailscale.yml
@@ -1,9 +1,0 @@
-services:
-  tailscale:
-    entrypoint:
-      - sh
-      - -c
-      - |
-        echo "Tailscale disabled (TS_AUTHKEY not set in .settings)."
-        echo "Sidecar is providing docker bridge networking only - no tailnet access."
-        exec sleep infinity

--- a/docker-compose.tailscale.yml
+++ b/docker-compose.tailscale.yml
@@ -1,0 +1,43 @@
+services:
+  tailscale:
+    image: tailscale/tailscale:latest
+    container_name: ${CONTAINER_NAME:-sam-dev-container-active}-ts
+    hostname: ${HOSTNAME:-sam-dev}
+    environment:
+      - TS_AUTHKEY=${TS_AUTHKEY}
+      - TS_HOSTNAME=${HOSTNAME:-sam-dev}
+      - TS_USERSPACE=false
+      - TS_STATE_DIR=/var/lib/tailscale
+      - TS_EXTRA_ARGS=--shields-up --accept-dns=true
+    volumes:
+      - tailscale-state:/var/lib/tailscale
+      - /dev/net/tun:/dev/net/tun
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    ports:
+      - "${HOST_PORTS:-3002}:${CONTAINER_PORTS:-3000}"
+      - "${HOST_PORT_RANGE:-3010-3019}:${CONTAINER_PORT_RANGE:-3010-3019}"
+      - "${NOVNC_HOST_PORT:-6080}:6080"
+    restart: unless-stopped
+
+  dev:
+    image: ${IMAGE_TAG:-sam-dev-container}
+    container_name: ${CONTAINER_NAME:-sam-dev-container-active}
+    network_mode: "service:tailscale"
+    depends_on:
+      - tailscale
+    shm_size: 2gb
+    environment:
+      - MCP_GATEWAY_AUTH_TOKEN=${MCP_GATEWAY_AUTH_TOKEN}
+      - ADO_ORG=${ADO_ORG}
+      - ENABLE_CLAUDEAI_MCP_SERVERS=false
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    security_opt:
+      - seccomp=custom-seccomp.json
+    stdin_open: true
+    tty: true
+
+volumes:
+  tailscale-state:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,32 +1,8 @@
 services:
-  tailscale:
-    image: tailscale/tailscale:latest
-    container_name: ${CONTAINER_NAME:-sam-dev-container-active}-ts
-    hostname: ${HOSTNAME:-sam-dev}
-    environment:
-      - TS_AUTHKEY=${TS_AUTHKEY}
-      - TS_HOSTNAME=${HOSTNAME:-sam-dev}
-      - TS_USERSPACE=false
-      - TS_STATE_DIR=/var/lib/tailscale
-      - TS_EXTRA_ARGS=--shields-up --accept-dns=true
-    volumes:
-      - tailscale-state:/var/lib/tailscale
-      - /dev/net/tun:/dev/net/tun
-    cap_add:
-      - NET_ADMIN
-      - NET_RAW
-    ports:
-      - "${HOST_PORTS:-3002}:${CONTAINER_PORTS:-3000}"
-      - "${HOST_PORT_RANGE:-3010-3019}:${CONTAINER_PORT_RANGE:-3010-3019}"
-      - "${NOVNC_HOST_PORT:-6080}:6080"
-    restart: unless-stopped
-
   dev:
     image: ${IMAGE_TAG:-sam-dev-container}
     container_name: ${CONTAINER_NAME:-sam-dev-container-active}
-    network_mode: "service:tailscale"
-    depends_on:
-      - tailscale
+    hostname: ${HOSTNAME:-sam-dev}
     shm_size: 2gb
     environment:
       - MCP_GATEWAY_AUTH_TOKEN=${MCP_GATEWAY_AUTH_TOKEN}
@@ -34,10 +10,11 @@ services:
       - ENABLE_CLAUDEAI_MCP_SERVERS=false
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - "${HOST_PORTS:-3002}:${CONTAINER_PORTS:-3000}"
+      - "${HOST_PORT_RANGE:-3010-3019}:${CONTAINER_PORT_RANGE:-3010-3019}"
+      - "${NOVNC_HOST_PORT:-6080}:6080"
     security_opt:
       - seccomp=custom-seccomp.json
     stdin_open: true
     tty: true
-
-volumes:
-  tailscale-state:

--- a/run.sh
+++ b/run.sh
@@ -54,6 +54,19 @@ NEED_OVERRIDE=false
 EXTRA_VOLUMES=""
 MOUNT_HOME=""
 COMPOSE_FILES=""
+USE_TAILSCALE=false
+TAILSCALE_COMPOSE_FILE="docker-compose.tailscale.yml"
+
+# Pick the right compose file for teardown based on whether the tailscale
+# sidecar container exists, so -k/-x clean up correctly regardless of how
+# the stack was started.
+teardown_compose_files() {
+    if docker ps -a --filter "name=^${CONTAINER_NAME}-ts$" --format '{{.Names}}' | grep -q .; then
+        echo "-f $TAILSCALE_COMPOSE_FILE"
+    else
+        echo "-f docker-compose.yml"
+    fi
+}
 
 # Check for DOCKER_VOLUMES environment variable
 if [[ -n "$DOCKER_VOLUMES" ]]; then
@@ -65,11 +78,11 @@ if [[ -n "$DOCKER_VOLUMES" ]]; then
     echo "Will mount additional volumes: $DOCKER_VOLUMES"
 fi
 
-while getopts ":krxbhm:" option; do
+while getopts ":krxbthm:" option; do
     case $option in
         k)
             echo "Stopping and removing containers..."
-            docker compose down
+            docker compose $(teardown_compose_files) down
             # Kill any host MCP gateway process
             pkill -f "docker mcp gateway" 2>/dev/null || true
             exit;;
@@ -79,7 +92,7 @@ while getopts ":krxbhm:" option; do
             exit;;
         x)
             echo "Stopping containers and deleting image..."
-            docker compose down
+            docker compose $(teardown_compose_files) down
             # Kill any host MCP gateway process
             pkill -f "docker mcp gateway" 2>/dev/null || true
             docker rmi ${IMAGE_TAG}
@@ -87,6 +100,9 @@ while getopts ":krxbhm:" option; do
         b)
             BUILD_FLAGS="--no-cache --pull"
             FORCE_BUILD=true
+            ;;
+        t)
+            USE_TAILSCALE=true
             ;;
         h)
             NEED_OVERRIDE=true
@@ -116,17 +132,19 @@ export MCP_GATEWAY_AUTH_TOKEN
 export ADO_ORG
 export TS_AUTHKEY
 
-# Set up compose files
-COMPOSE_FILES="-f docker-compose.yml"
-
-# If TS_AUTHKEY is not set, run the tailscale sidecar in passive mode
-# (no tailnet, just holds the netns so dev gets normal docker bridge networking).
-# Run this after getopts so teardown flags (-k/-r/-x) are unaffected.
-if [[ -z "$TS_AUTHKEY" || "$TS_AUTHKEY" == "tskey-auth-..." ]]; then
-    echo "Warning: TS_AUTHKEY not set - tailscale sidecar will run in passive mode."
-    echo "  No tailnet access; dev container has standard docker bridge networking."
-    echo "  To enable tailnet access, set TS_AUTHKEY in .settings (see settings.example)."
-    COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.no-tailscale.yml"
+# Set up compose files. Default is a single dev container with standard
+# docker bridge networking. Pass -t to opt into the tailscale sidecar.
+if [[ "$USE_TAILSCALE" == true ]]; then
+    if [[ -z "$TS_AUTHKEY" || "$TS_AUTHKEY" == "tskey-auth-..." ]]; then
+        echo "Error: -t requires TS_AUTHKEY to be set in .settings."
+        echo "  Generate one at https://login.tailscale.com/admin/settings/keys"
+        echo "  See settings.example. Omit -t to run without the sidecar."
+        exit 1
+    fi
+    COMPOSE_FILES="-f $TAILSCALE_COMPOSE_FILE"
+    echo "Tailscale sidecar enabled."
+else
+    COMPOSE_FILES="-f docker-compose.yml"
 fi
 
 # Start host MCP gateway if not already running

--- a/settings.example
+++ b/settings.example
@@ -5,8 +5,10 @@
 # Azure DevOps organization name (the part after dev.azure.com/)
 ADO_ORG="your-org-name"
 
-# Tailscale auth key for the sidecar (https://login.tailscale.com/admin/settings/keys)
-# A reusable, ephemeral key is recommended. The container registers in your
+# Tailscale auth key for the optional sidecar (https://login.tailscale.com/admin/settings/keys)
+# Only needed if you run with `./run.sh -t`. The default setup is a single
+# container with standard docker bridge networking (no sidecar).
+# A reusable, ephemeral key is recommended. The sidecar registers in your
 # tailnet using HOSTNAME as its device name and runs in shields-up mode, so it
 # can dial peers via MagicDNS but peers cannot dial it.
 TS_AUTHKEY="tskey-auth-..."


### PR DESCRIPTION
## Summary

- Restore the pre-sidecar single-container default. The tailscale sidecar setup is now opt-in via `./run.sh -t`.
- The sidecar's shared network namespace was flaky on laptops that change networks (the sidecar can lose its connection independently of the dev container). Single-container mode avoids that whole class of failure.
- Teardown ops (`-k`/`-x`) auto-detect whether the sidecar exists, so they clean up correctly regardless of how the stack was started.

## Changes

- `docker-compose.yml` — now the single-container default (bridge networking, ports on the dev service).
- `docker-compose.tailscale.yml` — prior sidecar setup, used only with `-t`.
- `docker-compose.no-tailscale.yml` — removed (no longer needed; opting out is the default).
- `run.sh` — adds `-t`; errors out if `-t` is passed without `TS_AUTHKEY`.
- `README.md` / `settings.example` — updated.

## Test plan

- [ ] `./run.sh` starts a single dev container with bridge networking; ports 3002 / 3010-3019 / 6080 published; MCP gateway reachable.
- [ ] `./run.sh -t` (with `TS_AUTHKEY` set) starts the tailscale sidecar + dev; tailnet peers reachable via MagicDNS.
- [ ] `./run.sh -t` without `TS_AUTHKEY` exits with the helpful error.
- [ ] `./run.sh -k` cleans up cleanly after both modes (no orphaned `*-ts` container).
- [ ] `./run.sh -h` and `./run.sh -m <path>` still produce a working `docker-compose.override.yml` against the new default.

https://claude.ai/code/session_01CWfmxvnD6TnCZ4Mriu86cR

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWfmxvnD6TnCZ4Mriu86cR)_