### PR TITLE
Update Node.js LTS version to jod and set as default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM mcr.microsoft.com/playwright:v1.45.3-noble AS sam-dev
 ARG D2_VERSION=0.7.1
 ARG NPM_VERSION=10.9.2
 ARG NVM_VERSION=0.40.3
-ARG NODE_LTS_NAME=iron
+ARG NODE_LTS_NAME=jod
 ARG GCF_PORT=38274
 ARG O2F_PORT=48272
 ARG PWSH_VERSION=7.5.4
@@ -80,7 +80,8 @@ RUN certutil -A -d sql:/home/devuser/.pki/nssdb -t "C,," -n server -i server.crt
 SHELL ["/bin/bash", "--login", "-c"]
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh | bash \
     && . ~/.nvm/nvm.sh \
-    && nvm install lts/${NODE_LTS_NAME}
+    && nvm install lts/${NODE_LTS_NAME} \
+    && nvm alias default lts/${NODE_LTS_NAME}
 RUN npm install -g npm@${NPM_VERSION}
 
 # Install Rust via rustup


### PR DESCRIPTION
## Summary
Updated the Node.js LTS version in the development Docker image from `iron` to `jod` and configured it as the default Node version in the container.

## Key Changes
- Updated `NODE_LTS_NAME` build argument from `iron` to `jod`
- Added `nvm alias default lts/${NODE_LTS_NAME}` command to set the installed LTS version as the default Node version for the container

## Implementation Details
The change ensures that when the development container starts, the `jod` LTS version of Node.js is not only installed but also set as the default version, eliminating the need to explicitly specify the Node version in subsequent shell sessions.

https://claude.ai/code/session_016wa8t9YHUDCH69yXUwVZwp