### PR TITLE
Add persistent /workspace volume per stack + workspace.sh management tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,10 @@ RUN mkdir -p /host-mnt
 RUN useradd -ms /bin/bash -u 1002 -G sudo devuser
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN echo 'Defaults env_keep += "http_proxy https_proxy HTTP_PROXY HTTPS_PROXY no_proxy NO_PROXY"' >> /etc/sudoers
+# Create /workspace mount point owned by devuser. When an empty named volume is
+# mounted here, Docker seeds it from this dir, so /workspace comes up
+# devuser-owned without a runtime chown. See workspace.sh / docker-compose*.yml.
+RUN mkdir -p /workspace && chown devuser:devuser /workspace
 WORKDIR /home/devuser
 USER devuser
 ENV TERM="xterm-256color"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,47 @@ Host (Docker Desktop)
 
 Pass `-t` to `run.sh` to opt into a Tailscale sidecar that owns the dev container's network namespace and provides outbound tailnet access. See [Tailscale](#tailscale) for details and trade-offs.
 
+## Workspace Volume
+
+Every container mounts a persistent `/workspace` directory at its root, owned by `devuser`. This is a normal Docker named volume (local driver — performant, not a bind mount) that **survives container recreation**: `docker compose down`/`up`, image rebuilds, and host reboots all leave it intact. Use it for code and data you want to keep between sessions; the rest of the container filesystem is disposable.
+
+Each stack gets its own volume so they stay independent:
+
+| Stack | Started by | Volume |
+| --- | --- | --- |
+| dev (plain + tailscale) | `run.sh` | `dev-workspace` |
+| experimental / YOLO | `run-exp.sh` | `exp-workspace` |
+
+The dev and tailscale stacks share `dev-workspace`, so your work is there whether or not you run with `-t`. The experimental container has a separate `exp-workspace`, so the isolated YOLO container can't touch your dev work.
+
+The volumes are declared in the compose files, so `run.sh` / `run-exp.sh` create them automatically on first start — there's nothing to set up. Ownership is handled automatically: Docker seeds a fresh volume from the image's `devuser`-owned `/workspace`, so `/workspace` comes up writable by `devuser` without any manual `chown`.
+
+### Managing the volume (`workspace.sh`)
+
+`workspace.sh` manages the volumes out-of-band. The first argument is the target stack (`dev`, the default, or `exp`):
+
+```bash
+./workspace.sh status [dev|exp]                 # mountpoint, disk usage, consumers
+./workspace.sh list                             # all workspace volumes
+./workspace.sh create   [dev|exp]               # create if missing (idempotent)
+./workspace.sh backup   [dev|exp] <file.tar.gz> # archive contents to a tarball
+./workspace.sh restore  [dev|exp] <file.tar.gz> # restore a tarball into the volume
+./workspace.sh delete   [dev|exp]               # remove the volume and all its data
+./workspace.sh recreate [dev|exp]               # delete + create an empty volume
+```
+
+Add `-y` / `--yes` to skip confirmation prompts. Destructive commands (`delete`, `recreate`, `restore`) refuse to run while a container is using the volume — stop it first with `./run.sh -k` or `./run-exp.sh -k`. Back up before you recreate:
+
+```bash
+./workspace.sh backup dev ~/dev-workspace.tar.gz   # snapshot first
+./workspace.sh recreate dev                        # start fresh
+./workspace.sh restore dev ~/dev-workspace.tar.gz  # …or roll back
+```
+
+`status`/`backup`/`restore` run a throwaway `alpine:3.19` container to read the volume; override the image with `WORKSPACE_HELPER_IMAGE` if needed.
+
+> Note: this is a plain named volume, so its size is not capped — `du`-style usage is reported by `status`, but writes are bounded only by host disk space.
+
 ### Docker Access via Claude
 
 Inside the container, Claude has access to Docker through MCP servers:

--- a/docker-compose.exp.yml
+++ b/docker-compose.exp.yml
@@ -52,6 +52,8 @@ services:
       - ADO_ORG=${ADO_ORG}
     security_opt:
       - seccomp=custom-seccomp.json
+    volumes:
+      - exp-workspace:/workspace
     depends_on:
       proxy:
         condition: service_healthy
@@ -62,6 +64,18 @@ services:
         sudo git config --system --unset-all credential.helper 2>/dev/null || true
         git config --global --unset-all credential.helper 2>/dev/null || true
         git config --global --unset credential.https://dev.azure.com.useHttpPath 2>/dev/null || true
+        # Ensure /workspace is owned by devuser (exp overrides the image
+        # entrypoint, so it can't rely on entrypoint.sh's safety chown).
+        sudo chown devuser:devuser /workspace 2>/dev/null || true
         exec sleep infinity
     stdin_open: true
     tty: true
+
+volumes:
+  # Persistent /workspace for the experimental stack. Separate from the dev
+  # stack so the isolated YOLO container can't touch dev work. `name:` pins a
+  # stable, unprefixed name matching workspace.sh.
+  exp-workspace:
+    name: exp-workspace
+    labels:
+      com.docker-dev.workspace: "exp"

--- a/docker-compose.tailscale.yml
+++ b/docker-compose.tailscale.yml
@@ -35,6 +35,7 @@ services:
       - ENABLE_CLAUDEAI_MCP_SERVERS=false
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - dev-workspace:/workspace
     security_opt:
       - seccomp=custom-seccomp.json
     stdin_open: true
@@ -42,3 +43,10 @@ services:
 
 volumes:
   tailscale-state:
+  # Shared with docker-compose.yml so the dev workspace persists whether or not
+  # the tailscale sidecar is in use. `name:` pins a stable, unprefixed name so
+  # both compose files and workspace.sh resolve to the same volume.
+  dev-workspace:
+    name: dev-workspace
+    labels:
+      com.docker-dev.workspace: "dev"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - ENABLE_CLAUDEAI_MCP_SERVERS=false
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - dev-workspace:/workspace
     ports:
       - "${HOST_PORTS:-3002}:${CONTAINER_PORTS:-3000}"
       - "${HOST_PORT_RANGE:-3010-3019}:${CONTAINER_PORT_RANGE:-3010-3019}"
@@ -18,3 +19,12 @@ services:
       - seccomp=custom-seccomp.json
     stdin_open: true
     tty: true
+
+volumes:
+  # Persistent /workspace for the dev stack. Survives container recreation.
+  # Managed out-of-band by workspace.sh. `name:` pins a stable, unprefixed
+  # volume name so it matches workspace.sh regardless of compose project name.
+  dev-workspace:
+    name: dev-workspace
+    labels:
+      com.docker-dev.workspace: "dev"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Ensure the /workspace named volume is owned by devuser. Normally Docker seeds
+# a fresh volume from the image's devuser-owned /workspace, but a volume
+# pre-created by workspace.sh comes up root-owned -- fix the top level here.
+if [ -d /workspace ] && [ "$(stat -c %u /workspace 2>/dev/null)" != "1002" ]; then
+    sudo chown devuser:devuser /workspace 2>/dev/null || true
+fi
+
 # Start Xvfb on display :99
 Xvfb ${DISPLAY} -screen 0 ${VNC_RESOLUTION:-1280x1024x24} -ac +extension GLX +render -noreset &
 

--- a/workspace.sh
+++ b/workspace.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+# workspace.sh -- manage the per-stack /workspace named volumes.
+#
+# Each dev stack gets its own persistent Docker named volume mounted at
+# /workspace inside the container, owned by devuser. These are normal local
+# named volumes (performant, not bind mounts) that survive container
+# recreation -- docker compose up/down, image rebuilds, host reboots. This
+# script manages their lifecycle out-of-band: inspect usage, back up / restore,
+# delete, and recreate.
+#
+#   dev  -> dev-workspace  (run.sh; shared by the plain and tailscale stacks)
+#   exp  -> exp-workspace  (run-exp.sh)
+#
+# docker compose already auto-creates these on first `up`, so for normal use
+# you don't need this script at all -- it's for managing the volumes directly.
+
+set -euo pipefail
+
+LABEL_KEY="com.docker-dev.workspace"
+# Throwaway image used for du / tar over the volume. alpine:3.19 is already
+# cached by the exp-proxy build stage; override with WORKSPACE_HELPER_IMAGE if
+# you prefer a different small image.
+HELPER_IMAGE="${WORKSPACE_HELPER_IMAGE:-alpine:3.19}"
+ASSUME_YES=false
+
+die() { echo "Error: $*" >&2; exit 1; }
+
+# Map a target name (dev|exp) to its volume name.
+vol_for() {
+    case "${1:-dev}" in
+        dev) echo "dev-workspace" ;;
+        exp) echo "exp-workspace" ;;
+        *)   die "unknown target '$1' (expected: dev or exp)" ;;
+    esac
+}
+
+vol_exists() { docker volume inspect "$1" >/dev/null 2>&1; }
+
+# Create the volume with its management label if it isn't there already.
+ensure_volume() {
+    local vol="$1" target="$2"
+    vol_exists "$vol" || docker volume create --label "${LABEL_KEY}=${target}" "$vol" >/dev/null
+}
+
+# Abort if any running container is currently using the volume.
+require_not_in_use() {
+    local vol="$1" running
+    running=$(docker ps --filter "volume=$vol" --format '{{.Names}}')
+    if [ -n "$running" ]; then
+        echo "Volume '$vol' is in use by running container(s):" >&2
+        echo "$running" | sed 's/^/  - /' >&2
+        die "stop them first (e.g. ./run.sh -k or ./run-exp.sh -k)"
+    fi
+}
+
+confirm() {
+    [ "$ASSUME_YES" = true ] && return 0
+    local ans
+    read -r -p "$1 [y/N] " ans
+    [[ "$ans" =~ ^[Yy]$ ]]
+}
+
+cmd_create() {
+    local target="${1:-dev}" vol
+    vol=$(vol_for "$target")
+    if vol_exists "$vol"; then
+        echo "Volume '$vol' already exists."
+        return 0
+    fi
+    docker volume create --label "${LABEL_KEY}=${target}" "$vol" >/dev/null
+    echo "Created volume '$vol'. It will be owned by devuser on next container start."
+}
+
+cmd_status() {
+    local target="${1:-dev}" vol mountpoint usage users
+    vol=$(vol_for "$target")
+    vol_exists "$vol" || die "volume '$vol' does not exist (run: ./workspace.sh create $target)"
+    mountpoint=$(docker volume inspect -f '{{.Mountpoint}}' "$vol")
+    usage=$(docker run --rm -v "$vol":/w "$HELPER_IMAGE" du -sh /w 2>/dev/null | cut -f1)
+    echo "Volume:     $vol"
+    echo "Mountpoint: $mountpoint"
+    echo "Usage:      ${usage:-unknown}"
+    users=$(docker ps -a --filter "volume=$vol" --format '{{.Names}} ({{.State}})')
+    if [ -n "$users" ]; then
+        echo "In use by:"
+        echo "$users" | sed 's/^/  - /'
+    else
+        echo "In use by:  (none)"
+    fi
+}
+
+cmd_list() {
+    echo "Workspace volumes:"
+    docker volume ls --filter "label=${LABEL_KEY}" --format '  {{.Name}}'
+}
+
+cmd_backup() {
+    local target="${1:-dev}" out="${2:-}" vol outdir outbase
+    vol=$(vol_for "$target")
+    vol_exists "$vol" || die "volume '$vol' does not exist"
+    [ -n "$out" ] || die "usage: ./workspace.sh backup <target> <file.tar.gz>"
+    mkdir -p "$(dirname "$out")"
+    outdir=$(cd "$(dirname "$out")" && pwd)
+    outbase=$(basename "$out")
+    docker run --rm -v "$vol":/w:ro -v "$outdir":/backup "$HELPER_IMAGE" \
+        tar czf "/backup/$outbase" -C /w .
+    echo "Backed up '$vol' -> $outdir/$outbase"
+}
+
+cmd_restore() {
+    local target="${1:-dev}" in="${2:-}" vol indir inbase
+    vol=$(vol_for "$target")
+    [ -n "$in" ] || die "usage: ./workspace.sh restore <target> <file.tar.gz>"
+    [ -f "$in" ] || die "backup file '$in' not found"
+    require_not_in_use "$vol"
+    ensure_volume "$vol" "$target"
+    indir=$(cd "$(dirname "$in")" && pwd)
+    inbase=$(basename "$in")
+    docker run --rm -v "$vol":/w -v "$indir":/backup:ro -e F="$inbase" "$HELPER_IMAGE" \
+        sh -c 'tar xzf "/backup/$F" -C /w'
+    echo "Restored $indir/$inbase -> '$vol'"
+}
+
+cmd_delete() {
+    local target="${1:-dev}" vol
+    vol=$(vol_for "$target")
+    vol_exists "$vol" || { echo "Volume '$vol' does not exist."; return 0; }
+    require_not_in_use "$vol"
+    confirm "Delete volume '$vol' and ALL its data?" || { echo "Aborted."; return 0; }
+    docker volume rm "$vol" >/dev/null
+    echo "Deleted volume '$vol'."
+}
+
+cmd_recreate() {
+    local target="${1:-dev}" vol
+    vol=$(vol_for "$target")
+    require_not_in_use "$vol"
+    if vol_exists "$vol"; then
+        confirm "Recreate volume '$vol'? This DELETES all current data (back up first with: ./workspace.sh backup $target <file>)." \
+            || { echo "Aborted."; return 0; }
+        docker volume rm "$vol" >/dev/null
+    fi
+    docker volume create --label "${LABEL_KEY}=${target}" "$vol" >/dev/null
+    echo "Recreated empty volume '$vol'. It will be owned by devuser on next container start."
+}
+
+usage() {
+cat <<'EOF'
+workspace.sh -- manage per-stack /workspace named volumes
+
+Usage: ./workspace.sh <command> [target] [args] [-y]
+
+Targets:
+  dev   dev-workspace   (default; run.sh, plain + tailscale stacks)
+  exp   exp-workspace   (run-exp.sh)
+
+Commands:
+  status   [target]                 show mountpoint, disk usage, and consumers
+  list                              list all workspace volumes
+  create   [target]                 create the volume if missing (idempotent)
+  ensure   [target]                 alias for create
+  backup   [target] <file.tar.gz>   archive the volume contents to a tarball
+  restore  [target] <file.tar.gz>   restore a tarball into the volume
+  delete   [target]                 remove the volume and all its data
+  recreate [target]                 delete + create an empty volume
+
+Options:
+  -y, --yes    skip confirmation prompts
+
+Notes:
+  * Volumes are normal Docker named volumes (local driver) and persist across
+    container recreation. docker compose also auto-creates them on first `up`.
+  * Destructive commands refuse to run while a container is using the volume;
+    stop it first (./run.sh -k or ./run-exp.sh -k). Back up before recreate.
+EOF
+}
+
+main() {
+    local args=()
+    for a in "$@"; do
+        case "$a" in
+            -y|--yes) ASSUME_YES=true ;;
+            *) args+=("$a") ;;
+        esac
+    done
+    set -- "${args[@]+"${args[@]}"}"
+
+    local cmd="${1:-}"
+    [ $# -gt 0 ] && shift
+    case "$cmd" in
+        status)         cmd_status "$@" ;;
+        list)           cmd_list "$@" ;;
+        create|ensure)  cmd_create "$@" ;;
+        backup)         cmd_backup "$@" ;;
+        restore)        cmd_restore "$@" ;;
+        delete|destroy) cmd_delete "$@" ;;
+        recreate)       cmd_recreate "$@" ;;
+        ""|-h|--help|help) usage ;;
+        *) usage; echo; die "unknown command '$cmd'" ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Every container now mounts a persistent `/workspace` directory at its root, owned by `devuser`, backed by a normal local named volume (performant, not a bind mount) that **survives container recreation** (`docker compose down`/`up`, image rebuilds, host reboots).

Each stack gets its own independent volume:

| Stack | Started by | Volume |
| --- | --- | --- |
| dev (plain + tailscale) | `run.sh` | `dev-workspace` |
| experimental / YOLO | `run-exp.sh` | `exp-workspace` |

The dev and tailscale stacks share `dev-workspace`; the isolated YOLO container gets a separate `exp-workspace` so it can't touch dev work.

## Changes

- **`Dockerfile`** — pre-creates a `devuser`-owned `/workspace`. Docker seeds a fresh named volume from this dir, so `/workspace` comes up `devuser`-owned on first mount with no runtime `chown`.
- **`docker-compose.yml` / `docker-compose.tailscale.yml`** — mount `dev-workspace:/workspace`; declare the volume with a pinned, unprefixed `name:` so compose and `workspace.sh` always resolve to the same volume regardless of compose project name.
- **`docker-compose.exp.yml`** — mount a separate `exp-workspace:/workspace`, plus an idempotent `chown` in the command (exp overrides the image entrypoint).
- **`entrypoint.sh`** — idempotent safety `chown` for volumes pre-created out-of-band.
- **`workspace.sh`** (new) — manage the volumes out-of-band: `status` (mountpoint, disk usage, consumers), `list`, `create`/`ensure`, `backup`, `restore`, `delete`, `recreate`. `-y` skips prompts; destructive commands refuse to run while a container holds the volume.
- **`README.md`** — new "Workspace Volume" section.

Volumes are declared in the compose files, so they're auto-created on first `up` — nothing to set up.

## Notes

- **Size:** this is a plain named volume bounded only by host disk space — no hard cap. `status` reports `du`-style usage; there is no resize.
- **Helper image:** `status`/`backup`/`restore` run a throwaway `alpine:3.19` (already cached by the exp-proxy build stage); override via `WORKSPACE_HELPER_IMAGE`.

## Testing

Verified against a live Docker daemon:

- create idempotence, `list`, `status` (disk usage + consumers)
- `backup` → `recreate` → `restore` round-trip, byte-for-byte
- a fresh volume inherits `devuser` (uid 1002) ownership from the image's `/workspace`
- in-use guard refuses `delete`/`recreate` (exit 1) while a container holds the volume
- all three compose files parse and render the volumes with stable, unprefixed names

https://claude.ai/code/session_01Cy8DNoccdz9iFmkMp4MwgA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy8DNoccdz9iFmkMp4MwgA)_